### PR TITLE
Twin naming and enum option update

### DIFF
--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -36,7 +36,7 @@ enum
 };
 
 /**
- * @brief Azure IoT Hub Client twin_content_type option values.
+ * @brief Azure IoT Hub Client `twin_content_type` option values.
  *
  */
 typedef enum
@@ -68,9 +68,9 @@ typedef struct
   az_span model_id;
 
   /**
-   * The `twin_content_type` determines the format to send in the username, which will inform IoT
-   * Hub what format the device expects the twin document to use. If this option is not set, the
-   * default is JSON.
+   * The `twin_content_type` determines the format to send in the username field properties, which
+   * will inform the IoT Hub what format the device expects the twin document to use. If this option
+   * is not set, the default is JSON.
    */
   az_iot_hub_client_option_twin_content_type twin_content_type;
 

--- a/sdk/inc/azure/iot/az_iot_hub_client.h
+++ b/sdk/inc/azure/iot/az_iot_hub_client.h
@@ -27,18 +27,6 @@
 #include <azure/core/_az_cfg_prefix.h>
 
 /**
- * @brief Azure IoT Hub Client `method_twin_content_type` option value: CBOR.
- * @note It can be used by wrapping the macro in an #AZ_SPAN_FROM_STR macro as a parameter.
- */
-#define AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR "application%2Fcbor"
-
-/**
- * @brief Azure IoT Hub Client `method_twin_content_type` option value: JSON.
- * @note It can be used by wrapping the macro in an #AZ_SPAN_FROM_STR macro as a parameter.
- */
-#define AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_JSON "application%2Fjson"
-
-/**
  * @brief Azure IoT service MQTT bit field properties for telemetry publish messages.
  *
  */
@@ -46,6 +34,16 @@ enum
 {
   AZ_HUB_CLIENT_DEFAULT_MQTT_TELEMETRY_QOS = 0
 };
+
+/**
+ * @brief Azure IoT Hub Client twin_content_type option values.
+ *
+ */
+typedef enum
+{
+  AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_DEFAULT_JSON = 0,
+  AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR = 1,
+} az_iot_hub_client_option_twin_content_type;
 
 /**
  * @brief Azure IoT Hub Client options.
@@ -64,17 +62,18 @@ typedef struct
   az_span user_agent;
 
   /**
-   * The `method_twin_content_type` is sent in the username to inform IoT Hub what format the device
-   * expects Twin Document and Direct Method payloads to use. If this option is not set, the default
-   * is JSON.
-   */
-  az_span method_twin_content_type;
-
-  /**
    * The `model_id` is used to identify the capabilities of a device based on the Digital Twin
    * Document.
    */
   az_span model_id;
+
+  /**
+   * The `twin_content_type` determines the format to send in the username, which will inform IoT
+   * Hub what format the device expects the twin document to use. If this option is not set, the
+   * default is JSON.
+   */
+  az_iot_hub_client_option_twin_content_type twin_content_type;
+
 } az_iot_hub_client_options;
 
 /**

--- a/sdk/samples/iot/paho_iot_hub_twin_cbor_sample.c
+++ b/sdk/samples/iot/paho_iot_hub_twin_cbor_sample.c
@@ -136,8 +136,7 @@ static void create_and_configure_mqtt_client(void)
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
 
   // Set the content type to CBOR for Direct Method payloads and Twin Document.
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   rc = az_iot_hub_client_init(&hub_client, env_vars.hub_hostname, env_vars.hub_device_id, &options);
   if (az_result_failed(rc))

--- a/sdk/src/azure/iot/az_iot_hub_client.c
+++ b/sdk/src/azure/iot/az_iot_hub_client.c
@@ -23,15 +23,16 @@ static const az_span hub_service_api_version = AZ_SPAN_LITERAL_FROM_STR("/?api-v
 static const az_span hub_client_sdk_version
     = AZ_SPAN_LITERAL_FROM_STR("DeviceClientType=c%2F" AZ_SDK_VERSION_STRING);
 static const az_span hub_digital_twin_model_id = AZ_SPAN_LITERAL_FROM_STR("model-id");
-static const az_span hub_method_twin_content_type
-    = AZ_SPAN_LITERAL_FROM_STR("default-content-type");
+static const az_span hub_twin_content_type = AZ_SPAN_LITERAL_FROM_STR("default-content-type");
+static const az_span hub_twin_content_type_cbor = AZ_SPAN_LITERAL_FROM_STR("application%2Fcbor");
 
 AZ_NODISCARD az_iot_hub_client_options az_iot_hub_client_options_default()
 {
   return (az_iot_hub_client_options){ .module_id = AZ_SPAN_EMPTY,
                                       .user_agent = hub_client_sdk_version,
                                       .model_id = AZ_SPAN_EMPTY,
-                                      .method_twin_content_type = AZ_SPAN_EMPTY };
+                                      .twin_content_type
+                                      = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_DEFAULT_JSON };
 }
 
 AZ_NODISCARD az_result az_iot_hub_client_init(
@@ -63,8 +64,9 @@ AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
 
   const az_span* const module_id = &(client->_internal.options.module_id);
   const az_span* const user_agent = &(client->_internal.options.user_agent);
-  const az_span* const method_twin_ct = &(client->_internal.options.method_twin_content_type);
   const az_span* const model_id = &(client->_internal.options.model_id);
+  az_iot_hub_client_option_twin_content_type const twin_ct
+      = client->_internal.options.twin_content_type;
 
   az_span mqtt_user_name_span
       = az_span_create((uint8_t*)mqtt_user_name, (int32_t)mqtt_user_name_size);
@@ -82,11 +84,12 @@ AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
   {
     required_length += az_span_size(hub_client_param_separator_span) + az_span_size(*user_agent);
   }
-  if (az_span_size(*method_twin_ct) > 0)
+  if (twin_ct != AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_DEFAULT_JSON)
   {
+    // Currently must be CBOR if not JSON
     required_length += az_span_size(hub_client_param_separator_span)
-        + az_span_size(hub_method_twin_content_type) + az_span_size(hub_client_param_equals_span)
-        + az_span_size(*method_twin_ct);
+        + az_span_size(hub_twin_content_type) + az_span_size(hub_client_param_equals_span)
+        + az_span_size(hub_twin_content_type_cbor);
   }
   if (az_span_size(*model_id) > 0)
   {
@@ -117,12 +120,12 @@ AZ_NODISCARD az_result az_iot_hub_client_get_user_name(
     remainder = az_span_copy_u8(remainder, *az_span_ptr(hub_client_param_separator_span));
     remainder = az_span_copy(remainder, *user_agent);
   }
-  if (az_span_size(*method_twin_ct) > 0)
+  if (twin_ct != AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_DEFAULT_JSON)
   {
     remainder = az_span_copy_u8(remainder, *az_span_ptr(hub_client_param_separator_span));
-    remainder = az_span_copy(remainder, hub_method_twin_content_type);
+    remainder = az_span_copy(remainder, hub_twin_content_type);
     remainder = az_span_copy_u8(remainder, *az_span_ptr(hub_client_param_equals_span));
-    remainder = az_span_copy(remainder, *method_twin_ct);
+    remainder = az_span_copy(remainder, hub_twin_content_type_cbor);
   }
   if (az_span_size(*model_id) > 0)
   {

--- a/sdk/tests/iot/hub/test_az_iot_hub_client.c
+++ b/sdk/tests/iot/hub/test_az_iot_hub_client.c
@@ -26,11 +26,11 @@
 #define TEST_MODULE_ID "my_module_id"
 #define TEST_API_VERSION "?api-version=2020-09-30"
 #define TEST_USER_AGENT "os=azrtos"
+#define TEST_CONTENT_TYPE_CBOR "application%2Fcbor"
 #define TEST_MODEL_ID "dtmi:YOUR_COMPANY_NAME_HERE:sample_device;1"
 #define TEST_PLATFORM_USER_AGENT "DeviceClientType=c%2F" AZ_SDK_VERSION_STRING
 #define MODEL_ID_PARAMETER "model-id=dtmi%3AYOUR_COMPANY_NAME_HERE%3Asample_device%3B1"
-#define CONTENT_TYPE_CBOR_PARAMETER \
-  "default-content-type=" AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR
+#define CONTENT_TYPE_CBOR_PARAMETER "default-content-type=" TEST_CONTENT_TYPE_CBOR
 
 static const az_span test_hub_hostname = AZ_SPAN_LITERAL_FROM_STR(TEST_HUB_HOSTNAME_STR);
 static const az_span test_device_id = AZ_SPAN_LITERAL_FROM_STR(TEST_DEVICE_ID_STR);
@@ -199,9 +199,8 @@ static void test_az_iot_hub_client_init_custom_options_succeed(void** state)
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
   options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
   options.model_id = AZ_SPAN_FROM_STR(TEST_MODEL_ID);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
 
@@ -222,13 +221,11 @@ static void test_az_iot_hub_client_init_custom_options_succeed(void** state)
       az_span_ptr(client._internal.options.user_agent),
       _az_COUNTOF(TEST_USER_AGENT) - 1);
   assert_memory_equal(
-      AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR,
-      az_span_ptr(client._internal.options.method_twin_content_type),
-      _az_COUNTOF(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR) - 1);
-  assert_memory_equal(
       TEST_MODEL_ID,
       az_span_ptr(client._internal.options.model_id),
       _az_COUNTOF(TEST_MODEL_ID) - 1);
+  assert_int_equal(
+      AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR, client._internal.options.twin_content_type);
 }
 
 static void test_az_iot_hub_client_get_user_name_succeed(void** state)
@@ -319,8 +316,7 @@ static void test_az_iot_hub_client_get_user_name_with_content_type_option_succee
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
@@ -344,8 +340,7 @@ static void test_az_iot_hub_client_get_user_name_with_content_type_option_small_
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
@@ -435,8 +430,7 @@ test_az_iot_hub_client_get_user_name_with_module_id_user_agent_content_type_opti
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
   options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
@@ -466,8 +460,7 @@ test_az_iot_hub_client_get_user_name_with_module_id_user_agent_content_type_opti
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
   options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
@@ -541,9 +534,8 @@ static void test_az_iot_hub_client_get_user_name_with_content_type_model_id_opti
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
   options.model_id = AZ_SPAN_FROM_STR(TEST_MODEL_ID);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
@@ -569,9 +561,8 @@ test_az_iot_hub_client_get_user_name_with_content_type_model_id_options_small_bu
 
   az_iot_hub_client client;
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
   options.model_id = AZ_SPAN_FROM_STR(TEST_MODEL_ID);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
@@ -595,9 +586,8 @@ test_az_iot_hub_client_get_user_name_with_module_id_user_agent_content_type_mode
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
   options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
   options.model_id = AZ_SPAN_FROM_STR(TEST_MODEL_ID);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);
@@ -628,9 +618,8 @@ test_az_iot_hub_client_get_user_name_with_module_id_user_agent_content_type_mode
   az_iot_hub_client_options options = az_iot_hub_client_options_default();
   options.module_id = AZ_SPAN_FROM_STR(TEST_MODULE_ID);
   options.user_agent = AZ_SPAN_FROM_STR(TEST_USER_AGENT);
-  options.method_twin_content_type
-      = AZ_SPAN_FROM_STR(AZ_IOT_HUB_CLIENT_OPTION_METHOD_TWIN_CONTENT_TYPE_CBOR);
   options.model_id = AZ_SPAN_FROM_STR(TEST_MODEL_ID);
+  options.twin_content_type = AZ_IOT_HUB_CLIENT_OPTION_TWIN_CONTENT_TYPE_CBOR;
 
   assert_int_equal(
       az_iot_hub_client_init(&client, test_hub_hostname, test_device_id, &options), AZ_OK);


### PR DESCRIPTION
- Changes naming to Twin only.
- Changes option from using a string literal to an enum.  Updates logic to build username.